### PR TITLE
feat: Add author profile component below blog posts

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -98,9 +98,9 @@ export default async function Blog({ params }: { params: Promise<{ slug: string 
       </article>
       <AuthorProfile
         author={{
-          name: 'My Portfolio',
+          name: 'Joey Kim',
           bio: 'A passionate developer sharing insights about web development, design, and technology.',
-          avatarUrl: 'https://avatar.vercel.sh/my-portfolio',
+          avatarUrl: 'https://avatar.vercel.sh/joey-kim',
         }}
       />
     </section>

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from 'next/navigation'
 import { CustomMDX } from 'app/components/mdx'
 import { formatDate, getBlogPosts } from 'app/blog/utils'
 import { baseUrl } from 'app/sitemap'
+import { AuthorProfile } from 'app/components/AuthorProfile'
 
 export async function generateStaticParams() {
   let posts = getBlogPosts()
@@ -11,8 +12,9 @@ export async function generateStaticParams() {
   }))
 }
 
-export function generateMetadata({ params }) {
-  let post = getBlogPosts().find((post) => post.slug === params.slug)
+export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+  let post = getBlogPosts().find((post) => post.slug === slug)
   if (!post) {
     return
   }
@@ -51,8 +53,9 @@ export function generateMetadata({ params }) {
   }
 }
 
-export default function Blog({ params }) {
-  let post = getBlogPosts().find((post) => post.slug === params.slug)
+export default async function Blog({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+  let post = getBlogPosts().find((post) => post.slug === slug)
 
   if (!post) {
     notFound()
@@ -93,6 +96,13 @@ export default function Blog({ params }) {
       <article className="prose">
         <CustomMDX source={post.content} />
       </article>
+      <AuthorProfile
+        author={{
+          name: 'My Portfolio',
+          bio: 'A passionate developer sharing insights about web development, design, and technology.',
+          avatarUrl: 'https://avatar.vercel.sh/my-portfolio',
+        }}
+      />
     </section>
   )
 }

--- a/app/components/AuthorProfile.tsx
+++ b/app/components/AuthorProfile.tsx
@@ -1,0 +1,29 @@
+interface AuthorProfileProps {
+  author: {
+    name: string
+    bio: string
+    avatarUrl: string
+  }
+}
+
+export function AuthorProfile({ author }: AuthorProfileProps) {
+  return (
+    <div className="mt-12 pt-8 border-t border-neutral-200 dark:border-neutral-800">
+      <div className="flex items-start gap-4">
+        <img
+          src={author.avatarUrl}
+          alt={`${author.name}'s avatar`}
+          className="w-16 h-16 rounded-full object-cover"
+        />
+        <div className="flex-1">
+          <h3 className="font-bold text-lg text-neutral-900 dark:text-neutral-100">
+            {author.name}
+          </h3>
+          <p className="mt-1 text-neutral-600 dark:text-neutral-400 text-sm leading-relaxed">
+            {author.bio}
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Created AuthorProfile component to display author information (avatar, name, bio) at the bottom of each blog post, providing a more personal touch for readers.

Also updated blog post page to support Next.js 15+ async params API by converting generateMetadata and Blog component to async functions with proper TypeScript types.

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>